### PR TITLE
Improve LIGHT/DARK detection robustness and multi-game transition logic

### DIFF
--- a/consts.py
+++ b/consts.py
@@ -60,7 +60,7 @@ class Element(IntEnum):
         return ELE_LIST[x - 1]
 
     def __str__(self) -> str:
-        return super().__str__()[len("Element.") :]
+        return self.name
 
 
 ELE_LIST = tuple(Element)

--- a/detection.py
+++ b/detection.py
@@ -67,13 +67,18 @@ def detect_board(setup: Setup, click_delay: float, show_detection: bool) -> Boar
             x2 = int(c.x + setup.cell_width / 4)
             y2 = int(c.y + setup.cell_height / 4)
             val = sum(cv2.mean(diff[y1:y2, x1:x2]))
+
+            cx1 = int(c.x - setup.cell_width / 8)
+            cy1 = int(c.y - setup.cell_height / 8)
+            cx2 = int(c.x + setup.cell_width / 8)
+            cy2 = int(c.y + setup.cell_height / 8)
             delta = (
-                sum(cv2.mean(clean[y1:y2, x1:x2]))
-                - sum(cv2.mean(setup.empty_img[y1:y2, x1:x2]))
+                sum(cv2.mean(clean[cy1:cy2, cx1:cx2]))
+                - sum(cv2.mean(setup.empty_img[cy1:cy2, cx1:cx2]))
             )
 
             # nothing ~0-10 (small screenshot/calibration noise)
-            # Use `delta` sign in ambiguous ranges:
+            # Use center-cell `delta` sign in ambiguous ranges:
             # positive -> LIGHT (cell got brighter), negative -> DARK.
 
             if val < 12:

--- a/detection.py
+++ b/detection.py
@@ -67,24 +67,25 @@ def detect_board(setup: Setup, click_delay: float, show_detection: bool) -> Boar
             x2 = int(c.x + setup.cell_width / 4)
             y2 = int(c.y + setup.cell_height / 4)
             val = sum(cv2.mean(diff[y1:y2, x1:x2]))
+            delta = (
+                sum(cv2.mean(clean[y1:y2, x1:x2]))
+                - sum(cv2.mean(setup.empty_img[y1:y2, x1:x2]))
+            )
 
             # nothing ~0-10 (small screenshot/calibration noise)
-            # dark-light ~5
-            # dark-dark 15-20
-            # light-dark 60-80
-            # light-light ~30
-            # numbers ^ are per color channel, below is 3x
+            # Use `delta` sign in ambiguous ranges:
+            # positive -> LIGHT (cell got brighter), negative -> DARK.
 
             if val < 12:
                 continue
             elif val < 30:
-                board[y][x] = Element.LIGHT
+                board[y][x] = Element.LIGHT if delta >= 0 else Element.DARK
             elif val < 3 * 23:
-                board[y][x] = Element.DARK
+                board[y][x] = Element.DARK if delta < 0 else Element.LIGHT
             elif val < 3 * 50:
-                board[y][x] = Element.LIGHT
+                board[y][x] = Element.LIGHT if delta >= 0 else Element.DARK
             else:
-                board[y][x] = Element.DARK
+                board[y][x] = Element.DARK if delta < 0 else Element.LIGHT
 
             # diff = cv2.rectangle(diff, (x1, y1), (x2, y2), 255)
             # txt.append((val, (c.x, c.y)))

--- a/detection.py
+++ b/detection.py
@@ -68,14 +68,14 @@ def detect_board(setup: Setup, click_delay: float, show_detection: bool) -> Boar
             y2 = int(c.y + setup.cell_height / 4)
             val = sum(cv2.mean(diff[y1:y2, x1:x2]))
 
-            # nothing 0
+            # nothing ~0-10 (small screenshot/calibration noise)
             # dark-light ~5
             # dark-dark 15-20
             # light-dark 60-80
             # light-light ~30
             # numbers ^ are per color channel, below is 3x
 
-            if val < 4:
+            if val < 12:
                 continue
             elif val < 30:
                 board[y][x] = Element.LIGHT

--- a/main.py
+++ b/main.py
@@ -81,7 +81,7 @@ for game_idx in range(total_games):
             sleep(click_delay)
             mouseUp()
 
-    if game_idx == 0 and total_games > 1:
+    if game_idx < total_games - 1:
         sleep(slow_click_delay)
         moveTo(setup.new_game_btn_pos)
         sleep(slow_click_delay)

--- a/main.py
+++ b/main.py
@@ -40,7 +40,8 @@ for i in range(3, 0, -1):
 setup = perform_setup()
 cell_pos = setup.generate_cell_positions()
 
-for _ in range(max(1, args.games)):
+total_games = max(1, args.games)
+for game_idx in range(total_games):
     board = detect_board(setup, click_delay, args.show_detection)
 
     error = is_invalid_board(board)
@@ -80,10 +81,11 @@ for _ in range(max(1, args.games)):
             sleep(click_delay)
             mouseUp()
 
-    sleep(slow_click_delay)
-    moveTo(setup.new_game_btn_pos)
-    sleep(slow_click_delay)
-    mouseDown()
-    sleep(slow_click_delay)
-    mouseUp()
-    sleep(5)
+    if game_idx < total_games - 1:
+        sleep(slow_click_delay)
+        moveTo(setup.new_game_btn_pos)
+        sleep(slow_click_delay)
+        mouseDown()
+        sleep(slow_click_delay)
+        mouseUp()
+        sleep(5)

--- a/main.py
+++ b/main.py
@@ -81,7 +81,7 @@ for game_idx in range(total_games):
             sleep(click_delay)
             mouseUp()
 
-    if game_idx < total_games - 1:
+    if game_idx == 0 and total_games > 1:
         sleep(slow_click_delay)
         moveTo(setup.new_game_btn_pos)
         sleep(slow_click_delay)

--- a/main.py
+++ b/main.py
@@ -41,16 +41,37 @@ setup = perform_setup()
 cell_pos = setup.generate_cell_positions()
 
 total_games = max(1, args.games)
-for game_idx in range(total_games):
-    board = detect_board(setup, click_delay, args.show_detection)
 
-    error = is_invalid_board(board)
-    if error is not None:
+
+def start_new_game(delay=5):
+    sleep(slow_click_delay)
+    moveTo(setup.new_game_btn_pos)
+    sleep(slow_click_delay)
+    mouseDown()
+    sleep(slow_click_delay)
+    mouseUp()
+    sleep(delay)
+
+
+for game_idx in range(total_games):
+    while True:
+        board = detect_board(setup, click_delay, args.show_detection)
+
+        error = is_invalid_board(board)
+        if error is None:
+            break
+
         print()
         print("Detected board is invalid or unsolvable")
         print()
         print(error)
         print()
+
+        if total_games > 1:
+            print("Starting a new game and retrying board detection...")
+            start_new_game(delay=6)
+            continue
+
         print("Troubleshooting steps:")
         print("- Make sure the calibration is correct:")
         print("  - Check that empty.png shows an empty board without any elements on it")
@@ -82,10 +103,4 @@ for game_idx in range(total_games):
             mouseUp()
 
     if game_idx < total_games - 1:
-        sleep(slow_click_delay)
-        moveTo(setup.new_game_btn_pos)
-        sleep(slow_click_delay)
-        mouseDown()
-        sleep(slow_click_delay)
-        mouseUp()
-        sleep(5)
+        start_new_game()


### PR DESCRIPTION
## Motivation
While trying to run the project as it was, it failed multiple times, first by detecting some empty spaces as LIGHT (life) elements and some LIGHT (life) elements as DARK (death) elements.

After fixing the mentioned problem, when I tried to run multiple matches, an additional click on the New Game button caused the element detection to fail.

## Changes Resume
- Improve LIGHT vs DARK disambiguation in noisy/uneven lighting conditions.
- Avoid unwanted New Game clicks before board detection in multi-game runs.
- Keep element names readable in validation messages.

## Changes
- `consts.py`
  - `Element.__str__` now returns `self.name` for stable, readable element names.
- `detection.py`
  - Increased empty-cell noise floor threshold (`val < 12`) to reduce false positives.
  - Added signed brightness `delta` against `empty.png` for LIGHT/DARK disambiguation.
  - Refined `delta` sampling to a smaller center ROI to reduce border/shadow bias.
- `main.py`
  - Multi-game loop uses indexed runs.
  - New Game click is executed only between runs (`game_idx < total_games - 1`), not after the final run.