### PR TITLE
Fixed New Game Double-Click

### DIFF
--- a/main.py
+++ b/main.py
@@ -86,4 +86,6 @@ for _ in range(max(1, args.games)):
     mouseDown()
     sleep(slow_click_delay)
     mouseUp()
-    sleep(5)
+    sleep(slow_click_delay)
+    moveTo(setup.deck1_pos)
+    sleep(5 - slow_click_delay)


### PR DESCRIPTION
Fixed a small bug where the program would sometimes click "New Game" again while moving to the Salt position, right after the board finished initializing.

Right after pressing the "New Game" button, the cursor will move to the Salt position instead of remaining on the button. Additionally, the extra timing is removed from the 5 second time at the end.